### PR TITLE
make workers recognize unavailable blocks 

### DIFF
--- a/packages/node/src/indexer/blockDispatcher/block-dispatcher.service.ts
+++ b/packages/node/src/indexer/blockDispatcher/block-dispatcher.service.ts
@@ -55,9 +55,10 @@ export class BlockDispatcherService
       project,
       dynamicDsService,
       async (blockNums: number[]): Promise<BlockContent[]> => {
-        // If specVersion not changed, a known overallSpecVer will be pass in
-        // Otherwise use api to fetch runtimes
-        return this.apiService.fetchBlocks(blockNums);
+        //filter out null values, they represent blocks that were not available in chain
+        return (await this.apiService.fetchBlocks(blockNums)).filter(
+          (block) => block !== null,
+        );
       },
     );
   }

--- a/packages/node/src/utils/near.ts
+++ b/packages/node/src/utils/near.ts
@@ -475,7 +475,7 @@ export async function fetchBlocksArray(
       }
     }),
   );
-  return results.filter((result) => result !== null);
+  return results;
 }
 
 export async function fetchBlocksBatches(
@@ -485,6 +485,7 @@ export async function fetchBlocksBatches(
   const blocks = await fetchBlocksArray(api, blockArray);
 
   const blockContentPromises = blocks.map(async (blockResult) => {
+    if (blockResult === null) return null; // unavailable blocks
     const block = await wrapBlock(api, blockResult);
     return {
       block,


### PR DESCRIPTION
# Description
Because Near regularly skips blocks we handle blocks missing, but this doesn't seem to be working when workers are enabled.
Make workers recognize blocks that are unavailable on chain. 

Fixes #45 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
