### PR TITLE
Update to the latest near api and use modular imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,8 +56,5 @@
       "prettier --write"
     ]
   },
-  "packageManager": "yarn@3.1.1",
-  "dependencies": {
-    "near-api-js": "^1.1.0"
-  }
+  "packageManager": "yarn@3.1.1"
 }

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update to latest near sdk and use modular imports (#144)
 
 ## [5.0.2] - 2025-05-01
 ### Changed

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -27,7 +27,7 @@
     "@nestjs/schedule": "^5.0.1",
     "@subql/common": "^5.6.0",
     "@subql/common-near": "workspace:*",
-    "@subql/node-core": "^18.0.4",
+    "@subql/node-core": "^18.1.0",
     "@subql/types-near": "workspace:*",
     "lodash": "^4.17.21",
     "reflect-metadata": "^0.1.13",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -19,6 +19,7 @@
     "subql-node-near": "./bin/run"
   },
   "dependencies": {
+    "@near-js/providers": "^2.0.2",
     "@nestjs/common": "^11.0.16",
     "@nestjs/core": "^11.0.10",
     "@nestjs/event-emitter": "^2.0.0",
@@ -29,7 +30,6 @@
     "@subql/node-core": "^18.0.4",
     "@subql/types-near": "workspace:*",
     "lodash": "^4.17.21",
-    "near-api-js": "^2.1.4",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
     "yargs": "^16.2.0"

--- a/packages/node/src/app.module.ts
+++ b/packages/node/src/app.module.ts
@@ -9,7 +9,7 @@ import { ConfigureModule } from './configure/configure.module';
 import { FetchModule } from './indexer/fetch.module';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const { version: nearSdkVersion } = require('near-api-js/package.json');
+const { version: nearSdkVersion } = require('@near-js/providers/package.json');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { version: packageVersion } = require('../package.json');
 
@@ -23,7 +23,7 @@ const { version: packageVersion } = require('../package.json');
     FetchModule,
     MetaModule.forRoot({
       version: packageVersion,
-      sdkVersion: { name: 'near-api-js', version: nearSdkVersion },
+      sdkVersion: { name: '@near-js/providers', version: nearSdkVersion },
     }),
   ],
   controllers: [],

--- a/packages/node/src/blockchain.service.spec.ts
+++ b/packages/node/src/blockchain.service.spec.ts
@@ -1,12 +1,12 @@
 // Copyright 2020-2025 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
-import * as Near from 'near-api-js';
+import { JsonRpcProvider } from '@near-js/providers';
 import { BlockchainService } from './blockchain.service';
 import { ApiService } from './indexer/api.service';
 
 const mockApiService = (): ApiService => {
-  const api = new Near.providers.JsonRpcProvider({
+  const api = new JsonRpcProvider({
     url: 'https://archival-rpc.mainnet.near.org',
   });
 

--- a/packages/node/src/blockchain.service.ts
+++ b/packages/node/src/blockchain.service.ts
@@ -77,8 +77,7 @@ export class BlockchainService
 
   // eslint-disable-next-line @typescript-eslint/require-await
   async getChainInterval(): Promise<number> {
-    const CHAIN_INTERVAL =
-      calcInterval(this.apiService.api).toNumber() * INTERVAL_PERCENT;
+    const CHAIN_INTERVAL = calcInterval(this.apiService.api) * INTERVAL_PERCENT;
 
     return Math.min(BLOCK_TIME_VARIANCE, CHAIN_INTERVAL);
   }

--- a/packages/node/src/indexer/api.service.ts
+++ b/packages/node/src/indexer/api.service.ts
@@ -1,7 +1,16 @@
 // Copyright 2020-2025 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
-import { ConnectionInfo } from '@near-js/providers/lib/fetch_json';
+import { JsonRpcProvider } from '@near-js/providers';
+import {
+  AccessKeyWithPublicKey,
+  BlockChangeResult,
+  BlockReference,
+  BlockResult,
+  ChangeResult,
+  EpochValidatorInfo,
+  GasPrice,
+} from '@near-js/types';
 import { Injectable } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 
@@ -14,16 +23,6 @@ import {
   IBlock,
   exitWithError,
 } from '@subql/node-core';
-import * as Near from 'near-api-js';
-import {
-  AccessKeyWithPublicKey,
-  BlockChangeResult,
-  BlockReference,
-  BlockResult,
-  ChangeResult,
-  EpochValidatorInfo,
-  GasPrice,
-} from 'near-api-js/lib/providers/provider';
 
 import { SubqueryProject } from '../configure/SubqueryProject';
 import * as NearUtil from '../utils/near';
@@ -32,16 +31,17 @@ import { BlockContent } from './types';
 
 const logger = getLogger('api');
 
+export type ConnectionInfo = ConstructorParameters<typeof JsonRpcProvider>[0];
 // Force this here as Near can skip blocks and node-core doesn't support null for blocks
 // TODO improve types and follow to where the check to filter out null blocks is
 type ForceFetchBatchFunc = (
-  api: Near.providers.JsonRpcProvider,
+  api: JsonRpcProvider,
   batch: number[],
 ) => Promise<IBlock<BlockContent>[]>;
 
 @Injectable()
 export class ApiService extends BaseApiService<
-  Near.providers.JsonRpcProvider,
+  JsonRpcProvider,
   SafeJsonRpcProvider,
   IBlock<BlockContent>[]
 > {
@@ -89,7 +89,7 @@ export class ApiService extends BaseApiService<
     return apiService;
   }
 
-  get api(): Near.providers.JsonRpcProvider {
+  get api(): JsonRpcProvider {
     return this.unsafeApi;
   }
 
@@ -102,8 +102,8 @@ export class ApiService extends BaseApiService<
   }
 }
 
-export class SafeJsonRpcProvider extends Near.providers.JsonRpcProvider {
-  constructor(private height: number, private connectionInfo: ConnectionInfo) {
+export class SafeJsonRpcProvider extends JsonRpcProvider {
+  constructor(private height: number, connectionInfo: ConnectionInfo) {
     super(connectionInfo);
   }
 

--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -1,6 +1,7 @@
 // Copyright 2020-2025 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
+import { JsonRpcProvider } from '@near-js/providers';
 import { Inject, Injectable } from '@nestjs/common';
 import {
   isBlockHandlerProcessor,
@@ -33,7 +34,6 @@ import {
   NearCustomDatasource,
   NearBlockFilter,
 } from '@subql/types-near';
-import { JsonRpcProvider } from 'near-api-js/lib/providers';
 import { BlockchainService } from '../blockchain.service';
 import * as NearUtil from '../utils/near';
 import { ApiService, SafeJsonRpcProvider } from './api.service';

--- a/packages/node/src/indexer/nearApi.connection.ts
+++ b/packages/node/src/indexer/nearApi.connection.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2025 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
-import { ConnectionInfo } from '@near-js/providers/lib/fetch_json';
+import { JsonRpcProvider } from '@near-js/providers';
 import {
   ApiConnectionError,
   ApiErrorType,
@@ -10,14 +10,13 @@ import {
   NetworkMetadataPayload,
 } from '@subql/node-core';
 import { IEndpointConfig } from '@subql/types-core';
-import * as Near from 'near-api-js';
-import { SafeJsonRpcProvider } from './api.service';
+import { SafeJsonRpcProvider, ConnectionInfo } from './api.service';
 import { BlockContent } from './types';
 
 const GENESIS_BLOCK = 9_820_210;
 
 type FetchFunc = (
-  api: Near.providers.JsonRpcProvider,
+  api: JsonRpcProvider,
   batch: number[],
 ) => Promise<IBlock<BlockContent>[]>;
 
@@ -27,7 +26,7 @@ const { version: packageVersion } = require('../../package.json');
 export class NearApiConnection
   implements
     IApiConnectionSpecific<
-      Near.providers.JsonRpcProvider,
+      JsonRpcProvider,
       SafeJsonRpcProvider,
       IBlock<BlockContent>[]
     >
@@ -35,7 +34,7 @@ export class NearApiConnection
   readonly networkMeta: NetworkMetadataPayload;
 
   private constructor(
-    public unsafeApi: Near.providers.JsonRpcProvider,
+    public unsafeApi: JsonRpcProvider,
     private fetchBlocksBatches: FetchFunc,
     chainId: string,
     genesisHash: string,
@@ -64,7 +63,7 @@ export class NearApiConnection
       headers: headers,
     };
 
-    const api = new Near.providers.JsonRpcProvider(connectionInfo);
+    const api = new JsonRpcProvider(connectionInfo);
     return new NearApiConnection(
       api,
       fetchBlockBatches,

--- a/packages/node/src/subcommands/testing.service.ts
+++ b/packages/node/src/subcommands/testing.service.ts
@@ -1,6 +1,7 @@
 // Copyright 2020-2025 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
+import { JsonRpcProvider } from '@near-js/providers';
 import { Inject, Injectable } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import {
@@ -11,7 +12,6 @@ import {
   ProjectService,
 } from '@subql/node-core';
 import { NearDatasource } from '@subql/types-near';
-import { JsonRpcProvider } from 'near-api-js/lib/providers';
 import { SubqueryProject } from '../configure/SubqueryProject';
 import { SafeJsonRpcProvider } from '../indexer/api.service';
 import { BlockContent } from '../indexer/types';

--- a/packages/node/src/utils/near.spec.ts
+++ b/packages/node/src/utils/near.spec.ts
@@ -1,6 +1,7 @@
 // Copyright 2020-2025 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
+import { JsonRpcProvider } from '@near-js/providers';
 import { IBlock } from '@subql/node-core';
 import {
   NearAction,
@@ -8,7 +9,6 @@ import {
   NearReceiptFilter,
   NearTransactionReceipt,
 } from '@subql/types-near';
-import * as Near from 'near-api-js';
 import { BlockContent } from '../indexer/types';
 import { fetchBlocksBatches, filterAction, filterReceipt } from './near';
 
@@ -30,11 +30,12 @@ function filterActions(
 }
 
 describe('Near api', () => {
-  let nearApi: Near.providers.JsonRpcProvider;
+  let nearApi: JsonRpcProvider;
 
   beforeAll(() => {
-    nearApi = new Near.providers.JsonRpcProvider({
-      url: 'https://archival-rpc.mainnet.near.org',
+    nearApi = new JsonRpcProvider({
+      // url: 'https://archival-rpc.mainnet.near.org',
+      url: 'https://near.lava.build:443',
     });
   });
 

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update to latest near sdk and use modular imports (#144)
 
 ## [4.1.0] - 2025-04-28
 ### Changed

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -17,9 +17,8 @@
     "/dist"
   ],
   "dependencies": {
-    "@subql/types-core": "^2.0.2",
-    "bn.js": "5.2.1",
-    "near-api-js": "^1.1.0"
+    "@near-js/providers": "^2.0.2",
+    "@subql/types-core": "^2.0.2"
   },
   "devDependencies": {
     "@types/app-module-path": "^2.2.0"

--- a/packages/types/src/global.ts
+++ b/packages/types/src/global.ts
@@ -1,9 +1,9 @@
 // Copyright 2020-2025 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
-import {providers} from 'near-api-js';
+import type {JsonRpcProvider} from '@near-js/providers';
 import '@subql/types-core/dist/global';
 
 declare global {
-  const api: providers.JsonRpcProvider;
+  const api: JsonRpcProvider;
 }

--- a/packages/types/src/interfaces.ts
+++ b/packages/types/src/interfaces.ts
@@ -1,8 +1,7 @@
 // Copyright 2020-2025 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
-import BN from 'bn.js';
-import {Chunk, BlockHeader} from 'near-api-js/lib/providers/provider';
+import type {Chunk, BlockHeader} from '@near-js/types';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export interface IArgs extends String {
@@ -19,7 +18,7 @@ export interface NearBlock {
 }
 
 export interface NearTransaction {
-  nonce: BN;
+  nonce: bigint;
   signer_id: string;
   public_key: string;
   receiver_id: string;
@@ -45,7 +44,7 @@ export interface NearTransactionReceipt {
   predecessor_id: string;
   Action?: {
     actions: NearAction[];
-    gas_price: BN;
+    gas_price: bigint;
     input_data_ids: string[];
     output_data_receivers: {
       data_id: string;
@@ -71,22 +70,22 @@ export interface DeployContract {
 export interface FunctionCall {
   method_name: string;
   args: IArgs;
-  gas: BN;
-  deposit: BN;
+  gas: bigint;
+  deposit: bigint;
 }
 
 export interface Transfer {
-  deposit: BN;
+  deposit: bigint;
 }
 
 export interface Stake {
-  stake: BN;
+  stake: bigint;
   public_key: string;
 }
 
 export interface AddKey {
   public_key: string;
-  access_key: {nonce: BN; permission: string};
+  access_key: {nonce: bigint; permission: string};
 }
 
 export interface DeleteKey {
@@ -113,7 +112,7 @@ export interface DelegateAction {
   actions: NonDelegateAction[];
   /// Nonce to ensure that the same delegate action is not sent twice by a relayer and should match for given account's `public_key`.
   /// After this action is processed it will increment.
-  nonce: BN;
+  nonce: bigint;
   /// The maximal height of the block in the blockchain below which the given DelegateAction is valid.
   max_block_height: number;
   /// Public key that is used to sign this delegated action.

--- a/packages/types/src/project.ts
+++ b/packages/types/src/project.ts
@@ -1,6 +1,7 @@
 // Copyright 2020-2025 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
+import {JsonRpcProvider} from '@near-js/providers';
 import {
   BaseTemplateDataSource,
   IProjectNetworkConfig,
@@ -15,7 +16,6 @@ import {
   SecondLayerHandlerProcessor_1_0_0,
   DsProcessor,
 } from '@subql/types-core';
-import {providers} from 'near-api-js';
 import {NearBlock, NearTransaction, NearAction, NearTransactionReceipt, ActionType} from './interfaces';
 
 export type RuntimeDatasourceTemplate = BaseTemplateDataSource<NearRuntimeDatasource>;
@@ -269,7 +269,7 @@ export type NearDatasourceProcessor<
     string,
     SecondLayerHandlerProcessorArray<K, F, any, DS>
   >
-> = DsProcessor<DS, P, providers.JsonRpcProvider>;
+> = DsProcessor<DS, P, JsonRpcProvider>;
 
 export type SecondLayerHandlerProcessor<
   K extends NearHandlerKind,
@@ -277,24 +277,8 @@ export type SecondLayerHandlerProcessor<
   E,
   DS extends NearCustomDatasource = NearCustomDatasource
 > =
-  | SecondLayerHandlerProcessor_0_0_0<
-      K,
-      RuntimeHandlerInputMap,
-      RuntimeHandlerFilterMap,
-      F,
-      E,
-      DS,
-      providers.JsonRpcProvider
-    >
-  | SecondLayerHandlerProcessor_1_0_0<
-      K,
-      RuntimeHandlerInputMap,
-      RuntimeHandlerFilterMap,
-      F,
-      E,
-      DS,
-      providers.JsonRpcProvider
-    >;
+  | SecondLayerHandlerProcessor_0_0_0<K, RuntimeHandlerInputMap, RuntimeHandlerFilterMap, F, E, DS, JsonRpcProvider>
+  | SecondLayerHandlerProcessor_1_0_0<K, RuntimeHandlerInputMap, RuntimeHandlerFilterMap, F, E, DS, JsonRpcProvider>;
 
 export type NearProject<DS extends NearDatasource = NearRuntimeDatasource> = CommonSubqueryProject<
   IProjectNetworkConfig,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1955,147 +1955,81 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@near-js/accounts@npm:0.1.4":
-  version: 0.1.4
-  resolution: "@near-js/accounts@npm:0.1.4"
+"@near-js/crypto@npm:2.0.2":
+  version: 2.0.2
+  resolution: "@near-js/crypto@npm:2.0.2"
   dependencies:
-    "@near-js/crypto": 0.0.5
-    "@near-js/providers": 0.0.7
-    "@near-js/signers": 0.0.5
-    "@near-js/transactions": 0.2.1
-    "@near-js/types": 0.0.4
-    "@near-js/utils": 0.0.4
-    ajv: ^8.11.2
-    ajv-formats: ^2.1.1
-    bn.js: 5.2.1
-    borsh: ^0.7.0
-    depd: ^2.0.0
-    near-abi: 0.1.1
-  checksum: b31fff8a84eff867f1e331cfef28bbb0d0760b8548dd1d042777ceb071ce49eea811069aabae26f2892c51f65564eaacf0045c2aa7caa20306ec46f94096b728
+    "@near-js/types": 2.0.2
+    "@near-js/utils": 2.0.2
+    "@noble/curves": 1.8.1
+    borsh: 1.0.0
+    randombytes: 2.1.0
+    secp256k1: 5.0.1
+  peerDependencies:
+    "@near-js/types": ^2.0.1
+    "@near-js/utils": ^2.0.1
+  checksum: 1ede6627a326d4fff78ca63a2e4513e14d5096fc7e7fb70f58fe3e405db26336cbe2bd5b904b849a873680be210d11884fcac44e7d28f214708aa26ab1dca1a2
   languageName: node
   linkType: hard
 
-"@near-js/crypto@npm:0.0.5":
-  version: 0.0.5
-  resolution: "@near-js/crypto@npm:0.0.5"
+"@near-js/providers@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "@near-js/providers@npm:2.0.2"
   dependencies:
-    "@near-js/types": 0.0.4
-    bn.js: 5.2.1
-    borsh: ^0.7.0
-    tweetnacl: ^1.0.1
-  checksum: 9043b80827c5a701cf803a7a68bb5788f1c5c0b8b2a04ac73abf935acb357c8fc3e8265f103f1cc8c5e64312a309b229ca1dfd582994e7be3441199d7ddeb921
-  languageName: node
-  linkType: hard
-
-"@near-js/keystores-browser@npm:0.0.5":
-  version: 0.0.5
-  resolution: "@near-js/keystores-browser@npm:0.0.5"
-  dependencies:
-    "@near-js/crypto": 0.0.5
-    "@near-js/keystores": 0.0.5
-  checksum: 66cb57bf99c0b676a340b7a0cceac25d0660bc250316f3d02530a30ad919f33d203cdbf78a287ff83490e48b35f3fb2f693ac8c22ddcb99ffd0b24abde7a3632
-  languageName: node
-  linkType: hard
-
-"@near-js/keystores-node@npm:0.0.5":
-  version: 0.0.5
-  resolution: "@near-js/keystores-node@npm:0.0.5"
-  dependencies:
-    "@near-js/crypto": 0.0.5
-    "@near-js/keystores": 0.0.5
-  checksum: 09a21aee523ec65680cbc842be06412b93fe14449c094343f3cb28211eba84165976f9cff6161ae138f18502f35b601e81d9502a1dc7d1ab20b0358bf330f168
-  languageName: node
-  linkType: hard
-
-"@near-js/keystores@npm:0.0.5":
-  version: 0.0.5
-  resolution: "@near-js/keystores@npm:0.0.5"
-  dependencies:
-    "@near-js/crypto": 0.0.5
-    "@near-js/types": 0.0.4
-  checksum: a1cc994d7b16c8c4bdba86570591bc9a86c3dcf396be7d055b84d0786959873377f5d7cef838563780b0afec480319a28f3711d35edff1ef2562fbf634a0c55a
-  languageName: node
-  linkType: hard
-
-"@near-js/providers@npm:0.0.7":
-  version: 0.0.7
-  resolution: "@near-js/providers@npm:0.0.7"
-  dependencies:
-    "@near-js/transactions": 0.2.1
-    "@near-js/types": 0.0.4
-    "@near-js/utils": 0.0.4
-    bn.js: 5.2.1
-    borsh: ^0.7.0
-    http-errors: ^1.7.2
-    node-fetch: ^2.6.1
+    "@near-js/crypto": 2.0.2
+    "@near-js/transactions": 2.0.2
+    "@near-js/types": 2.0.2
+    "@near-js/utils": 2.0.2
+    borsh: 1.0.0
+    exponential-backoff: ^3.1.2
+    node-fetch: 2.6.7
+  peerDependencies:
+    "@near-js/crypto": ^2.0.1
+    "@near-js/transactions": ^2.0.1
+    "@near-js/types": ^2.0.1
+    "@near-js/utils": ^2.0.1
   dependenciesMeta:
     node-fetch:
       optional: true
-  checksum: 6302f1dde283a4ddb488eb037feb46866039fbb5353ab518186d2cba6e27aa4c803c7e425be9bda8ce360fd88a0480a29982e2c40eb6b554218ce24a0ab134db
+  checksum: b076212f1a0015aeec11534e944d0f2289c51eb879dce513c48686c307049fe72a8f83aea42bb265345b2686beef46f1a7efbd538fcbaf4e4d40053aaefad8db
   languageName: node
   linkType: hard
 
-"@near-js/signers@npm:0.0.5":
-  version: 0.0.5
-  resolution: "@near-js/signers@npm:0.0.5"
+"@near-js/transactions@npm:2.0.2":
+  version: 2.0.2
+  resolution: "@near-js/transactions@npm:2.0.2"
   dependencies:
-    "@near-js/crypto": 0.0.5
-    "@near-js/keystores": 0.0.5
-    js-sha256: ^0.9.0
-  checksum: d18b3351823aba277a3a38a6b23019fb19a3265e0eb8d04154db350b501e2cd20642df67c4393927500baf87fd85a4f6f53fe38752786d3d06aa7b360e030b1c
+    "@near-js/crypto": 2.0.2
+    "@near-js/types": 2.0.2
+    "@near-js/utils": 2.0.2
+    "@noble/hashes": 1.7.1
+    borsh: 1.0.0
+  peerDependencies:
+    "@near-js/crypto": ^2.0.1
+    "@near-js/types": ^2.0.1
+    "@near-js/utils": ^2.0.1
+  checksum: 56868f5060dc2fea3a4d9a5c327eab0e2e55dd66d3248bbb8d53d42859d47c7692cee93ec734062a3b9e49423b678d236911263f5746eff959420eda36b105dc
   languageName: node
   linkType: hard
 
-"@near-js/transactions@npm:0.2.1":
-  version: 0.2.1
-  resolution: "@near-js/transactions@npm:0.2.1"
-  dependencies:
-    "@near-js/crypto": 0.0.5
-    "@near-js/signers": 0.0.5
-    "@near-js/types": 0.0.4
-    "@near-js/utils": 0.0.4
-    bn.js: 5.2.1
-    borsh: ^0.7.0
-    js-sha256: ^0.9.0
-  checksum: 9eb498443963e766fa1573e1bdd9dcb70c95f5418dc427c42a8fdf3b189fbdbb46d1b4b441458696b429e4cf4af0fcdd6869ee7ff21f878718e25f79526ab83b
+"@near-js/types@npm:2.0.2":
+  version: 2.0.2
+  resolution: "@near-js/types@npm:2.0.2"
+  checksum: d25a99ce43b53f9231ef5090a101d13f37ced089f8267cac1ee264d43cdad4399af817e4d88d7833c03f6cf8fae8525a7a415b4076e69c71b1518fd78754d3c5
   languageName: node
   linkType: hard
 
-"@near-js/types@npm:0.0.4":
-  version: 0.0.4
-  resolution: "@near-js/types@npm:0.0.4"
+"@near-js/utils@npm:2.0.2":
+  version: 2.0.2
+  resolution: "@near-js/utils@npm:2.0.2"
   dependencies:
-    bn.js: 5.2.1
-  checksum: 2c84e0aad6352aac59a8455d52556ec6c6c61f12c3f10d20150d17c5cc2ca24bbba4ff22890447fb2d8289b09bf6c5084312927f3ff35637d17decd2fc5b3374
-  languageName: node
-  linkType: hard
-
-"@near-js/utils@npm:0.0.4":
-  version: 0.0.4
-  resolution: "@near-js/utils@npm:0.0.4"
-  dependencies:
-    "@near-js/types": 0.0.4
-    bn.js: 5.2.1
-    depd: ^2.0.0
-    mustache: ^4.0.0
-  checksum: 5037f6b1a27ccd5e9ceb558ba5243751ade90e8f58165a9400c6a807f0dedfc169dcdd3cbc33248acd0969fedd660056e33243bfa3625b5b71c630f95e8bc66f
-  languageName: node
-  linkType: hard
-
-"@near-js/wallet-account@npm:0.0.7":
-  version: 0.0.7
-  resolution: "@near-js/wallet-account@npm:0.0.7"
-  dependencies:
-    "@near-js/accounts": 0.1.4
-    "@near-js/crypto": 0.0.5
-    "@near-js/keystores": 0.0.5
-    "@near-js/signers": 0.0.5
-    "@near-js/transactions": 0.2.1
-    "@near-js/types": 0.0.4
-    "@near-js/utils": 0.0.4
-    bn.js: 5.2.1
-    borsh: ^0.7.0
-  checksum: 6dca6034a8ed796874a7fb78dbf715dbd88eb68129b06dfc960b87bf5dde64c305a6e4ed41d2b1da7cf620ada0b5c46d909037c514bf60eafda334078e25188f
+    "@near-js/types": 2.0.2
+    "@scure/base": ^1.2.4
+    depd: 2.0.0
+    mustache: 4.0.0
+  peerDependencies:
+    "@near-js/types": ^2.0.1
+  checksum: 6b5efe55f56f147f49633c403562c31f5c70d32851eca21bb41f2715dcc43f6df2da454b77074f7a6e9d8b57e825967f97872c99574569feae90a1af5f62c406
   languageName: node
   linkType: hard
 
@@ -2236,6 +2170,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@noble/curves@npm:1.8.1":
+  version: 1.8.1
+  resolution: "@noble/curves@npm:1.8.1"
+  dependencies:
+    "@noble/hashes": 1.7.1
+  checksum: 4143f1248ed57c1ae46dfef5c692a91383e5830420b9c72d3ff1061aa9ebbf8999297da6d2aed8a9716fef8e6b1f5a45737feeab02abf55ca2a4f514bf9339ec
+  languageName: node
+  linkType: hard
+
 "@noble/curves@npm:^1.3.0":
   version: 1.4.0
   resolution: "@noble/curves@npm:1.4.0"
@@ -2249,6 +2192,13 @@ __metadata:
   version: 1.4.0
   resolution: "@noble/hashes@npm:1.4.0"
   checksum: 8ba816ae26c90764b8c42493eea383716396096c5f7ba6bea559993194f49d80a73c081f315f4c367e51bd2d5891700bcdfa816b421d24ab45b41cb03e4f3342
+  languageName: node
+  linkType: hard
+
+"@noble/hashes@npm:1.7.1":
+  version: 1.7.1
+  resolution: "@noble/hashes@npm:1.7.1"
+  checksum: 4f1b56428a10323feef17e4f437c9093556cb18db06f94d254043fadb69c3da8475f96eb3f8322d41e8670117d7486475a8875e68265c2839f60fd03edd6a616
   languageName: node
   linkType: hard
 
@@ -2608,6 +2558,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@scure/base@npm:^1.2.4":
+  version: 1.2.6
+  resolution: "@scure/base@npm:1.2.6"
+  checksum: 1058cb26d5e4c1c46c9cc0ae0b67cc66d306733baf35d6ebdd8ddaba242b80c3807b726e3b48cb0411bb95ec10d37764969063ea62188f86ae9315df8ea6b325
+  languageName: node
+  linkType: hard
+
 "@sinclair/typebox@npm:^0.27.8":
   version: 0.27.8
   resolution: "@sinclair/typebox@npm:0.27.8"
@@ -2710,6 +2667,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@subql/node-near@workspace:packages/node"
   dependencies:
+    "@near-js/providers": ^2.0.2
     "@nestjs/common": ^11.0.16
     "@nestjs/core": ^11.0.10
     "@nestjs/event-emitter": ^2.0.0
@@ -2729,7 +2687,6 @@ __metadata:
     "@types/yargs": ^16.0.4
     dotenv: ^15.0.1
     lodash: ^4.17.21
-    near-api-js: ^2.1.4
     nodemon: ^2.0.15
     reflect-metadata: ^0.1.13
     rimraf: ^3.0.2
@@ -2759,10 +2716,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@subql/types-near@workspace:packages/types"
   dependencies:
+    "@near-js/providers": ^2.0.2
     "@subql/types-core": ^2.0.2
     "@types/app-module-path": ^2.2.0
-    bn.js: 5.2.1
-    near-api-js: ^1.1.0
   languageName: unknown
   linkType: soft
 
@@ -3093,7 +3049,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/json-schema@npm:^7.0.11, @types/json-schema@npm:^7.0.9":
+"@types/json-schema@npm:^7.0.9":
   version: 7.0.13
   resolution: "@types/json-schema@npm:7.0.13"
   checksum: 345df21a678fa72fb389f35f33de77833d09d4a142bb2bcb27c18690efa4cf70fc2876e43843cefb3fbdb9fcb12cd3e970a90936df30f53bbee899865ff605ab
@@ -3589,7 +3545,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv-formats@npm:2.1.1, ajv-formats@npm:^2.1.1":
+"ajv-formats@npm:2.1.1":
   version: 2.1.1
   resolution: "ajv-formats@npm:2.1.1"
   dependencies:
@@ -3603,7 +3559,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:8.12.0, ajv@npm:^8.0.0, ajv@npm:^8.11.2":
+"ajv@npm:8.12.0, ajv@npm:^8.0.0":
   version: 8.12.0
   resolution: "ajv@npm:8.12.0"
   dependencies:
@@ -4018,15 +3974,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base-x@npm:^3.0.2":
-  version: 3.0.11
-  resolution: "base-x@npm:3.0.11"
-  dependencies:
-    safe-buffer: ^5.0.1
-  checksum: c2e3c443fd07cb9b9d3e179a9e9c581daa31881005841fe8d6a834e534505890fedf03465ccf14512da60e3f7be00fe66167806b159ba076d2c03952ae7460c4
-  languageName: node
-  linkType: hard
-
 "base64-js@npm:^1.3.1":
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
@@ -4066,7 +4013,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bn.js@npm:5.2.1, bn.js@npm:^5.2.0, bn.js@npm:^5.2.1":
+"bn.js@npm:^4.11.9":
+  version: 4.12.2
+  resolution: "bn.js@npm:4.12.2"
+  checksum: dd224afda6f5a7d15f2fe5154e1a1c245576a725584ea1852c8c42f9748dfe847bc63a48b2885360023389a24cfebb3653ca97f4c69742f3c22bc63da6565030
+  languageName: node
+  linkType: hard
+
+"bn.js@npm:^5.2.1":
   version: 5.2.1
   resolution: "bn.js@npm:5.2.1"
   checksum: 3dd8c8d38055fedfa95c1d5fc3c99f8dd547b36287b37768db0abab3c239711f88ff58d18d155dd8ad902b0b0cee973747b7ae20ea12a09473272b0201c9edd3
@@ -4097,14 +4051,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"borsh@npm:^0.7.0":
-  version: 0.7.0
-  resolution: "borsh@npm:0.7.0"
-  dependencies:
-    bn.js: ^5.2.0
-    bs58: ^4.0.0
-    text-encoding-utf-8: ^1.0.2
-  checksum: e98bfb5f7cfb820819c2870b884dac58dd4b4ce6a86c286c8fbf5c9ca582e73a8c6094df67e81a28c418ff07a309c6b118b2e27fdfea83fd92b8100c741da0b5
+"borsh@npm:1.0.0":
+  version: 1.0.0
+  resolution: "borsh@npm:1.0.0"
+  checksum: fbb2101a30e94537a330b6158d513c497d760f4ddfc457e1431120a201f06eb05b7879100581e95deff07aad974cabc394da708a0be322ad26697177eadd123b
   languageName: node
   linkType: hard
 
@@ -4152,6 +4102,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"brorand@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "brorand@npm:1.1.0"
+  checksum: 8a05c9f3c4b46572dec6ef71012b1946db6cae8c7bb60ccd4b7dd5a84655db49fe043ecc6272e7ef1f69dc53d6730b9e2a3a03a8310509a3d797a618cbee52be
+  languageName: node
+  linkType: hard
+
 "browserslist@npm:^4.21.10, browserslist@npm:^4.21.9":
   version: 4.22.0
   resolution: "browserslist@npm:4.22.0"
@@ -4172,15 +4129,6 @@ __metadata:
   dependencies:
     fast-json-stable-stringify: 2.x
   checksum: d34bdaf68c64bd099ab97c3ea608c9ae7d3f5faa1178b3f3f345acd94e852e608b2d4f9103fb2e503f5e69780e98293df41691b84be909b41cf5045374d54606
-  languageName: node
-  linkType: hard
-
-"bs58@npm:^4.0.0":
-  version: 4.0.1
-  resolution: "bs58@npm:4.0.1"
-  dependencies:
-    base-x: ^3.0.2
-  checksum: b3c5365bb9e0c561e1a82f1a2d809a1a692059fae016be233a6127ad2f50a6b986467c3a50669ce4c18929dcccb297c5909314dd347a25a68c21b68eb3e95ac2
   languageName: node
   linkType: hard
 
@@ -4316,13 +4264,6 @@ __metadata:
   version: 1.0.30001540
   resolution: "caniuse-lite@npm:1.0.30001540"
   checksum: 95b9203a85ad0187a2480c341bfff6f32d61b9eb9cc323d2942025cd29fbe3f9c3dd056646996d303a0a42c968954f32994f97250e931b2ea5b9531099d6ba2d
-  languageName: node
-  linkType: hard
-
-"capability@npm:^0.2.5":
-  version: 0.2.5
-  resolution: "capability@npm:0.2.5"
-  checksum: 59ce65958dc0f2e76e7007fe8d5a0a85801b950bb957779c11948776f0e7a1290b9638bfd2da92b4b8bebd7584f92a8c38d4e6613659c9637783a6993026b08b
   languageName: node
   linkType: hard
 
@@ -4979,13 +4920,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"depd@npm:~1.1.2":
-  version: 1.1.2
-  resolution: "depd@npm:1.1.2"
-  checksum: 6b406620d269619852885ce15965272b829df6f409724415e0002c8632ab6a8c0a08ec1f0bd2add05dc7bd7507606f7e2cc034fa24224ab829580040b835ecd9
-  languageName: node
-  linkType: hard
-
 "deprecation@npm:^2.0.0, deprecation@npm:^2.3.1":
   version: 2.3.1
   resolution: "deprecation@npm:2.3.1"
@@ -5130,6 +5064,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"elliptic@npm:^6.5.7":
+  version: 6.6.1
+  resolution: "elliptic@npm:6.6.1"
+  dependencies:
+    bn.js: ^4.11.9
+    brorand: ^1.1.0
+    hash.js: ^1.0.0
+    hmac-drbg: ^1.0.1
+    inherits: ^2.0.4
+    minimalistic-assert: ^1.0.1
+    minimalistic-crypto-utils: ^1.0.1
+  checksum: 27b14a52f68bbbc0720da259f712cb73e953f6d2047958cd02fb0d0ade2e83849dc39fb4af630889c67df8817e24237428cf59c4f4c07700f755b401149a7375
+  languageName: node
+  linkType: hard
+
 "emittery@npm:^0.13.1":
   version: 0.13.1
   resolution: "emittery@npm:0.13.1"
@@ -5206,17 +5155,6 @@ __metadata:
   dependencies:
     is-arrayish: ^0.2.1
   checksum: c1c2b8b65f9c91b0f9d75f0debaa7ec5b35c266c2cac5de412c1a6de86d4cbae04ae44e510378cb14d032d0645a36925d0186f8bb7367bcc629db256b743a001
-  languageName: node
-  linkType: hard
-
-"error-polyfill@npm:^0.1.3":
-  version: 0.1.3
-  resolution: "error-polyfill@npm:0.1.3"
-  dependencies:
-    capability: ^0.2.5
-    o3: ^1.0.3
-    u3: ^0.1.1
-  checksum: 1aee485841310e1f4d10cde0a5c8ac840311c94914bb1aed8fd71826be84dd5dba3d4ab937f39c0b970edb3d0a76cfb5d001ec979db6c68858b5f75c1f504c52
   languageName: node
   linkType: hard
 
@@ -5683,6 +5621,13 @@ __metadata:
   version: 3.1.1
   resolution: "exponential-backoff@npm:3.1.1"
   checksum: 3d21519a4f8207c99f7457287291316306255a328770d320b401114ec8481986e4e467e854cb9914dd965e0a1ca810a23ccb559c642c88f4c7f55c55778a9b48
+  languageName: node
+  linkType: hard
+
+"exponential-backoff@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "exponential-backoff@npm:3.1.2"
+  checksum: 7e191e3dd6edd8c56c88f2c8037c98fbb8034fe48778be53ed8cb30ccef371a061a4e999a469aab939b92f8f12698f3b426d52f4f76b7a20da5f9f98c3cbc862
   languageName: node
   linkType: hard
 
@@ -6483,12 +6428,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hash.js@npm:^1.0.0, hash.js@npm:^1.0.3":
+  version: 1.1.7
+  resolution: "hash.js@npm:1.1.7"
+  dependencies:
+    inherits: ^2.0.3
+    minimalistic-assert: ^1.0.1
+  checksum: e350096e659c62422b85fa508e4b3669017311aa4c49b74f19f8e1bc7f3a54a584fdfd45326d4964d6011f2b2d882e38bea775a96046f2a61b7779a979629d8f
+  languageName: node
+  linkType: hard
+
 "hasown@npm:^2.0.2":
   version: 2.0.2
   resolution: "hasown@npm:2.0.2"
   dependencies:
     function-bind: ^1.1.2
   checksum: e8516f776a15149ca6c6ed2ae3110c417a00b62260e222590e54aa367cbcd6ed99122020b37b7fbdf05748df57b265e70095d7bf35a47660587619b15ffb93db
+  languageName: node
+  linkType: hard
+
+"hmac-drbg@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "hmac-drbg@npm:1.0.1"
+  dependencies:
+    hash.js: ^1.0.3
+    minimalistic-assert: ^1.0.0
+    minimalistic-crypto-utils: ^1.0.1
+  checksum: bd30b6a68d7f22d63f10e1888aee497d7c2c5c0bb469e66bbdac99f143904d1dfe95f8131f95b3e86c86dd239963c9d972fcbe147e7cffa00e55d18585c43fe0
   languageName: node
   linkType: hard
 
@@ -6525,19 +6491,6 @@ __metadata:
     statuses: 2.0.1
     toidentifier: 1.0.1
   checksum: 9b0a3782665c52ce9dc658a0d1560bcb0214ba5699e4ea15aefb2a496e2ca83db03ebc42e1cce4ac1f413e4e0d2d736a3fd755772c556a9a06853ba2a0b7d920
-  languageName: node
-  linkType: hard
-
-"http-errors@npm:^1.7.2":
-  version: 1.8.1
-  resolution: "http-errors@npm:1.8.1"
-  dependencies:
-    depd: ~1.1.2
-    inherits: 2.0.4
-    setprototypeof: 1.2.0
-    statuses: ">= 1.5.0 < 2"
-    toidentifier: 1.0.1
-  checksum: d3c7e7e776fd51c0a812baff570bdf06fe49a5dc448b700ab6171b1250e4cf7db8b8f4c0b133e4bfe2451022a5790c1ca6c2cae4094dedd6ac8304a1267f91d2
   languageName: node
   linkType: hard
 
@@ -7675,13 +7628,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-sha256@npm:^0.9.0":
-  version: 0.9.0
-  resolution: "js-sha256@npm:0.9.0"
-  checksum: ffad54b3373f81581e245866abfda50a62c483803a28176dd5c28fd2d313e0bdf830e77dac7ff8afd193c53031618920f3d98daf21cbbe80082753ab639c0365
-  languageName: node
-  linkType: hard
-
 "js-sha3@npm:^0.8.0":
   version: 0.8.0
   resolution: "js-sha3@npm:0.8.0"
@@ -8336,6 +8282,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimalistic-assert@npm:^1.0.0, minimalistic-assert@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "minimalistic-assert@npm:1.0.1"
+  checksum: cc7974a9268fbf130fb055aff76700d7e2d8be5f761fb5c60318d0ed010d839ab3661a533ad29a5d37653133385204c503bfac995aaa4236f4e847461ea32ba7
+  languageName: node
+  linkType: hard
+
+"minimalistic-crypto-utils@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "minimalistic-crypto-utils@npm:1.0.1"
+  checksum: 6e8a0422b30039406efd4c440829ea8f988845db02a3299f372fceba56ffa94994a9c0f2fd70c17f9969eedfbd72f34b5070ead9656a34d3f71c0bd72583a0ed
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^3.0.4, minimatch@npm:^3.0.5, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
@@ -8572,12 +8532,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mustache@npm:^4.0.0":
-  version: 4.2.0
-  resolution: "mustache@npm:4.2.0"
+"mustache@npm:4.0.0":
+  version: 4.0.0
+  resolution: "mustache@npm:4.0.0"
   bin:
-    mustache: bin/mustache
-  checksum: 928fcb63e3aa44a562bfe9b59ba202cccbe40a46da50be6f0dd831b495be1dd7e38ca4657f0ecab2c1a89dc7bccba0885eab7ee7c1b215830da765758c7e0506
+    mustache: ./bin/mustache
+  checksum: dcb2bf2d2a611a21f5e467ffe95dd6aa9e178bdc1d893251a5ac2b1c8f19912e48feed1bb392bba030056d23a68c009f3f80631dff81183a28e75045ef63d975
   languageName: node
   linkType: hard
 
@@ -8592,63 +8552,6 @@ __metadata:
   version: 1.4.0
   resolution: "natural-compare@npm:1.4.0"
   checksum: 23ad088b08f898fc9b53011d7bb78ec48e79de7627e01ab5518e806033861bef68d5b0cd0e2205c2f36690ac9571ff6bcb05eb777ced2eeda8d4ac5b44592c3d
-  languageName: node
-  linkType: hard
-
-"near-abi@npm:0.1.1":
-  version: 0.1.1
-  resolution: "near-abi@npm:0.1.1"
-  dependencies:
-    "@types/json-schema": ^7.0.11
-  checksum: 25b01b50b9a820250ad3ccf88164af242e1bbb895f1d14836b66d518fb3c016a66929959c1e3dda8ec2e2a8def23fc15843b8343a3b245da93727d86f8282425
-  languageName: node
-  linkType: hard
-
-"near-api-js@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "near-api-js@npm:1.1.0"
-  dependencies:
-    bn.js: 5.2.1
-    borsh: ^0.7.0
-    bs58: ^4.0.0
-    depd: ^2.0.0
-    error-polyfill: ^0.1.3
-    http-errors: ^1.7.2
-    js-sha256: ^0.9.0
-    mustache: ^4.0.0
-    node-fetch: ^2.6.1
-    text-encoding-utf-8: ^1.0.2
-    tweetnacl: ^1.0.1
-  checksum: 22a01a248b2b68a7fe1d6a98fd0d928143e44dad8f213b887942bfbddd23341ebf001d968c1e1acf8f601e410b1e7868a73369079e5852bbf1e2c5a0b938b9ac
-  languageName: node
-  linkType: hard
-
-"near-api-js@npm:^2.1.4":
-  version: 2.1.4
-  resolution: "near-api-js@npm:2.1.4"
-  dependencies:
-    "@near-js/accounts": 0.1.4
-    "@near-js/crypto": 0.0.5
-    "@near-js/keystores": 0.0.5
-    "@near-js/keystores-browser": 0.0.5
-    "@near-js/keystores-node": 0.0.5
-    "@near-js/providers": 0.0.7
-    "@near-js/signers": 0.0.5
-    "@near-js/transactions": 0.2.1
-    "@near-js/types": 0.0.4
-    "@near-js/utils": 0.0.4
-    "@near-js/wallet-account": 0.0.7
-    ajv: ^8.11.2
-    ajv-formats: ^2.1.1
-    bn.js: 5.2.1
-    borsh: ^0.7.0
-    depd: ^2.0.0
-    error-polyfill: ^0.1.3
-    http-errors: ^1.7.2
-    near-abi: 0.1.1
-    node-fetch: ^2.6.1
-    tweetnacl: ^1.0.1
-  checksum: 6717fef0c061b288dbec528768d6f0548319029008c10371bcd6fa0b8a659e92bec636cace3504e93e0282b0e4755e8b90b89c3a2c8b590414264a862ab38f22
   languageName: node
   linkType: hard
 
@@ -8675,6 +8578,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-addon-api@npm:^5.0.0":
+  version: 5.1.0
+  resolution: "node-addon-api@npm:5.1.0"
+  dependencies:
+    node-gyp: latest
+  checksum: 2508bd2d2981945406243a7bd31362fc7af8b70b8b4d65f869c61731800058fb818cc2fd36c8eac714ddd0e568cc85becf5e165cebbdf7b5024d5151bbc75ea1
+  languageName: node
+  linkType: hard
+
 "node-fetch@npm:2.6.7":
   version: 2.6.7
   resolution: "node-fetch@npm:2.6.7"
@@ -8686,6 +8598,17 @@ __metadata:
     encoding:
       optional: true
   checksum: 8d816ffd1ee22cab8301c7756ef04f3437f18dace86a1dae22cf81db8ef29c0bf6655f3215cb0cdb22b420b6fe141e64b26905e7f33f9377a7fa59135ea3e10b
+  languageName: node
+  linkType: hard
+
+"node-gyp-build@npm:^4.2.0":
+  version: 4.8.4
+  resolution: "node-gyp-build@npm:4.8.4"
+  bin:
+    node-gyp-build: bin.js
+    node-gyp-build-optional: optional.js
+    node-gyp-build-test: build-test.js
+  checksum: 8b81ca8ffd5fa257ad8d067896d07908a36918bc84fb04647af09d92f58310def2d2b8614d8606d129d9cd9b48890a5d2bec18abe7fcff54818f72bedd3a7d74
   languageName: node
   linkType: hard
 
@@ -8814,15 +8737,6 @@ __metadata:
   dependencies:
     boolbase: ^1.0.0
   checksum: 5afc3dafcd1573b08877ca8e6148c52abd565f1d06b1eb08caf982e3fa289a82f2cae697ffb55b5021e146d60443f1590a5d6b944844e944714a5b549675bcd3
-  languageName: node
-  linkType: hard
-
-"o3@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "o3@npm:1.0.3"
-  dependencies:
-    capability: ^0.2.5
-  checksum: 3b4d0686c94ac21b3c8bd66fb2c93a4daef7b8f52a20b04595754f8dc4102550de9a7b1cdffa3db2191d47a4ae70ca568f21d9f3ba29bb15c3f004dbf636c33c
   languageName: node
   linkType: hard
 
@@ -9683,6 +9597,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"randombytes@npm:2.1.0":
+  version: 2.1.0
+  resolution: "randombytes@npm:2.1.0"
+  dependencies:
+    safe-buffer: ^5.1.0
+  checksum: d779499376bd4cbb435ef3ab9a957006c8682f343f14089ed5f27764e4645114196e75b7f6abf1cbd84fd247c0cb0651698444df8c9bf30e62120fbbc52269d6
+  languageName: node
+  linkType: hard
+
 "range-parser@npm:^1.2.1":
   version: 1.2.1
   resolution: "range-parser@npm:1.2.1"
@@ -10115,7 +10038,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-buffer@npm:5.2.1, safe-buffer@npm:^5.0.1, safe-buffer@npm:~5.2.0":
+"safe-buffer@npm:5.2.1, safe-buffer@npm:^5.1.0, safe-buffer@npm:~5.2.0":
   version: 5.2.1
   resolution: "safe-buffer@npm:5.2.1"
   checksum: b99c4b41fdd67a6aaf280fcd05e9ffb0813654894223afb78a31f14a19ad220bba8aba1cb14eddce1fcfb037155fe6de4e861784eb434f7d11ed58d1e70dd491
@@ -10144,6 +10067,18 @@ __metadata:
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
   checksum: cab8f25ae6f1434abee8d80023d7e72b598cf1327164ddab31003c51215526801e40b66c5e65d658a0af1e9d6478cadcb4c745f4bd6751f97d8644786c0978b0
+  languageName: node
+  linkType: hard
+
+"secp256k1@npm:5.0.1":
+  version: 5.0.1
+  resolution: "secp256k1@npm:5.0.1"
+  dependencies:
+    elliptic: ^6.5.7
+    node-addon-api: ^5.0.0
+    node-gyp: latest
+    node-gyp-build: ^4.2.0
+  checksum: e21fb801502fe03a233f04c294cfdf16bd6087c36caa6514ccc5eac38ebd5ff50090a59d0ee7d50adf87f6d508a8211d09b905290fac97b4d43751967b7dfd9e
   languageName: node
   linkType: hard
 
@@ -10538,13 +10473,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"statuses@npm:>= 1.5.0 < 2":
-  version: 1.5.0
-  resolution: "statuses@npm:1.5.0"
-  checksum: c469b9519de16a4bb19600205cffb39ee471a5f17b82589757ca7bd40a8d92ebb6ed9f98b5a540c5d302ccbc78f15dc03cc0280dd6e00df1335568a5d5758a5c
-  languageName: node
-  linkType: hard
-
 "streamsearch@npm:^1.1.0":
   version: 1.1.0
   resolution: "streamsearch@npm:1.1.0"
@@ -10736,7 +10664,6 @@ __metadata:
     husky: ^7.0.4
     jest: ^29.5.0
     lint-staged: ^12.3.3
-    near-api-js: ^1.1.0
     node-fetch: 2.6.7
     prettier: ^2.5.1
     pretty-quick: ^3.1.3
@@ -10866,13 +10793,6 @@ __metadata:
     glob: ^7.1.4
     minimatch: ^3.0.4
   checksum: 3b34a3d77165a2cb82b34014b3aba93b1c4637a5011807557dc2f3da826c59975a5ccad765721c4648b39817e3472789f9b0fa98fc854c5c1c7a1e632aacdc28
-  languageName: node
-  linkType: hard
-
-"text-encoding-utf-8@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "text-encoding-utf-8@npm:1.0.2"
-  checksum: ec4c15d50e738c5dba7327ad432ebf0725ec75d4d69c0bd55609254c5a3bc5341272d7003691084a0a73d60d981c8eb0e87603676fdb6f3fed60f4c9192309f9
   languageName: node
   linkType: hard
 
@@ -11132,13 +11052,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tweetnacl@npm:^1.0.1":
-  version: 1.0.3
-  resolution: "tweetnacl@npm:1.0.3"
-  checksum: e4a57cac188f0c53f24c7a33279e223618a2bfb5fea426231991652a13247bea06b081fd745d71291fcae0f4428d29beba1b984b1f1ce6f66b06a6d1ab90645c
-  languageName: node
-  linkType: hard
-
 "type-check@npm:^0.4.0, type-check@npm:~0.4.0":
   version: 0.4.0
   resolution: "type-check@npm:0.4.0"
@@ -11277,13 +11190,6 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: fc52962f31a5bcb716d4213bef516885e4f01f30cea797a831205fc9ef12b405a40561c40eae3127ab85ba1548e7df49df2bcdee6b84a94bfbe3a0d7eff16b14
-  languageName: node
-  linkType: hard
-
-"u3@npm:^0.1.1":
-  version: 0.1.1
-  resolution: "u3@npm:0.1.1"
-  checksum: d55f396c607b0a2340d6165526b5143a29b369e7e0397b04f79633db77cd668f2da713feb7adb4f93a588e82a388ff995d9a2b16123d0cb02fe394fd2f26b529
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2631,9 +2631,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@subql/node-core@npm:^18.0.4":
-  version: 18.0.4
-  resolution: "@subql/node-core@npm:18.0.4"
+"@subql/node-core@npm:^18.1.0":
+  version: 18.1.0
+  resolution: "@subql/node-core@npm:18.1.0"
   dependencies:
     "@apollo/client": ^3.11.2
     "@nestjs/common": ^11.0.16
@@ -2642,7 +2642,7 @@ __metadata:
     "@subql/common": 5.6.0
     "@subql/testing": 2.2.4
     "@subql/types": 3.12.2
-    "@subql/utils": 2.18.1
+    "@subql/utils": 2.19.0
     "@willsoto/nestjs-prometheus": ^6.0.2
     async-mutex: ^0.5.0
     cron-converter: ^2.0.1
@@ -2659,7 +2659,7 @@ __metadata:
     toposort-class: ^1.0.1
     vm2: ^3.9.19
     yargs: ^16.2.0
-  checksum: 484574ba436fc984c8fda83e6904246636cd3c0eb92ea77201b9823dcce35a531cb70eaf239546679b1a2ac2d43231d3bce16c26500e5804142921b9417e0a2d
+  checksum: adfb16ccb3da46c74605dfb335bcb65c5914bc3ff68ca68b43e22b135f6a2717eeefa8348b8e32cb76dee12d6b8c43f39bcbb80b9027152529986545b2b5b4ee
   languageName: node
   linkType: hard
 
@@ -2677,7 +2677,7 @@ __metadata:
     "@nestjs/testing": ^9.4.0
     "@subql/common": ^5.6.0
     "@subql/common-near": "workspace:*"
-    "@subql/node-core": ^18.0.4
+    "@subql/node-core": ^18.1.0
     "@subql/types-near": "workspace:*"
     "@types/express": ^4.17.13
     "@types/jest": ^27.4.0
@@ -2733,9 +2733,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@subql/utils@npm:2.18.1":
-  version: 2.18.1
-  resolution: "@subql/utils@npm:2.18.1"
+"@subql/utils@npm:2.19.0":
+  version: 2.19.0
+  resolution: "@subql/utils@npm:2.19.0"
   dependencies:
     "@polkadot/util": ^13.4.4
     "@polkadot/util-crypto": ^13.4.4
@@ -2748,7 +2748,7 @@ __metadata:
     lodash: ^4.17.21
     pino: ^6.13.3
     rotating-file-stream: ^3.2.3
-  checksum: cc680225def170d0b7cbccc757ab31cc4ef1fefff2793e6c544a79ffd4746b97713409e19b19d2cf85e9fb660aa8e12c5c4cd486b8e24470c252dc52899c4d17
+  checksum: b37fb552fcebe649d898441444c112d511095a0ff16e40a739700b684e66c33b0b0355ea41d6666fbaf1f722a63d34065cd5a61a5a559cbe609dfb5a36ea76ad
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description
Update to the latest Near api dependencies and use the suggested modular imports. This includes a breaking change where BN.js is replaced with native bigint

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
